### PR TITLE
Chirag Maliwal: Add Days to Hire Statistics Feature

### DIFF
--- a/home_task/api.py
+++ b/home_task/api.py
@@ -1,0 +1,44 @@
+from typing import Dict, Optional
+from fastapi import FastAPI, HTTPException
+from sqlalchemy import select
+
+from home_task.db import get_session
+from home_task.models import DaysToHireStats
+
+app = FastAPI(title="Days to Hire Statistics API")
+
+@app.get("/stats")
+async def get_stats(standard_job_id: str, country_code: Optional[str] = None) -> Dict:
+    """Get hiring statistics for a specific job and optionally a specific country.
+    
+    Args:
+        standard_job_id: ID of the standard job to get statistics for
+        country_code: Optional country code to filter statistics by
+    
+    Returns:
+        Dictionary containing min, max, average days to hire and number of job postings
+    
+    Raises:
+        HTTPException: If statistics are not found or on server error
+    """
+    with get_session() as session:
+        try:
+            query = select(DaysToHireStats).where(
+                DaysToHireStats.standard_job_id == standard_job_id,
+                DaysToHireStats.country_code == country_code
+            )
+            result = session.execute(query).scalar()
+
+            if not result:
+                raise HTTPException(status_code=404, detail="Statistics not found")
+
+            return {
+                "standard_job_id": result.standard_job_id,
+                "country_code": result.country_code,
+                "min_days": float(result.min_days),
+                "avg_days": float(result.avg_days),
+                "max_days": float(result.max_days),
+                "job_postings_number": result.job_postings_number,
+            }
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e)) 

--- a/home_task/cli.py
+++ b/home_task/cli.py
@@ -1,0 +1,123 @@
+import uuid
+from statistics import mean, quantiles
+from typing import List, Dict, Optional
+from sqlalchemy import func, select, text
+from sqlalchemy.dialects.postgresql import insert
+
+from home_task.db import get_session
+from home_task.models import JobPosting, DaysToHireStats
+
+
+def calculate_stats(values: List[int], min_postings: int = 5) -> Optional[Dict]:
+    """Calculate statistics from a list of days to hire values.
+    
+    Args:
+        values: List of days to hire values
+        min_postings: Minimum number of postings required
+    
+    Returns:
+        Dictionary with min, max, avg days and posting count, or None if insufficient data
+    """
+    if len(values) < min_postings:
+        return None
+    
+    sorted_values = sorted(values)
+    min_days, max_days = quantiles(sorted_values, n=10)[0], quantiles(sorted_values, n=10)[-1]
+    filtered_values = [v for v in sorted_values if min_days <= v <= max_days]
+    
+    return {
+        'min_days': float(min_days),
+        'max_days': float(max_days),
+        'avg_days': float(mean(filtered_values)),
+        'job_postings_number': len(values)
+    }
+
+
+def process_chunk(session, query, chunk_size: int = 1000) -> None:
+    """Process a chunk of data and insert statistics.
+    
+    Args:
+        session: SQLAlchemy session
+        query: Base query to execute
+        chunk_size: Size of each chunk to process
+    """
+    offset = 0
+    while True:
+        # Get chunk of data
+        chunk = session.execute(
+            query.limit(chunk_size).offset(offset)
+        ).fetchall()
+        
+        if not chunk:
+            break
+            
+        # Process each row in chunk
+        for row in chunk:
+            if stats := calculate_stats(row.days_to_hire):
+                session.execute(
+                    insert(DaysToHireStats).values(
+                        id=str(uuid.uuid4()),
+                        standard_job_id=row.standard_job_id,
+                        country_code=getattr(row, 'country_code', None),
+                        **stats
+                    )
+                )
+        
+        # Commit chunk and update offset
+        session.commit()
+        offset += chunk_size
+
+
+def update_stats(session) -> None:
+    """Update statistics in the database using SQLAlchemy ORM efficiently.
+    
+    Args:
+        session: SQLAlchemy session
+    """
+    try:
+        # Clear existing stats within transaction
+        session.execute(text('TRUNCATE TABLE days_to_hire_stats'))
+        session.commit()
+        
+        # Base query for aggregating days_to_hire
+        base_query = (
+            select(
+                JobPosting.standard_job_id,
+                JobPosting.country_code,
+                func.array_agg(JobPosting.days_to_hire).label('days_to_hire'),
+                func.count().label('posting_count')
+            )
+            .where(JobPosting.days_to_hire.isnot(None))
+            .group_by(JobPosting.standard_job_id, JobPosting.country_code)
+            .having(func.count() >= 5)
+        )
+        
+        # Process country-specific stats
+        country_query = base_query.order_by(
+            JobPosting.standard_job_id,
+            JobPosting.country_code
+        )
+        process_chunk(session, country_query)
+        
+        # Process global stats (NULL country_code)
+        global_query = (
+            select(
+                JobPosting.standard_job_id,
+                func.array_agg(JobPosting.days_to_hire).label('days_to_hire'),
+                func.count().label('posting_count')
+            )
+            .where(JobPosting.days_to_hire.isnot(None))
+            .group_by(JobPosting.standard_job_id)
+            .having(func.count() >= 5)
+            .order_by(JobPosting.standard_job_id)
+        )
+        process_chunk(session, global_query)
+        
+    except Exception as e:
+        session.rollback()
+        raise e
+
+
+if __name__ == '__main__':
+    with get_session() as session:
+        update_stats(session) 

--- a/home_task/db.py
+++ b/home_task/db.py
@@ -3,7 +3,10 @@ from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 engine = create_engine("postgresql+psycopg2://admin:adm1n_password@localhost/home_task",)
 pg_session_factory = sessionmaker(
-    engine, Session, autocommit=False, autoflush=False, expire_on_commit=False
+    bind=engine,
+    autocommit=False,
+    autoflush=False,
+    expire_on_commit=False
 )
 SessionFactory = scoped_session(pg_session_factory)
 

--- a/home_task/models.py
+++ b/home_task/models.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     Integer,
     String,
     Table,
+    Float,
 )
 from sqlalchemy.orm import registry
 
@@ -67,3 +68,28 @@ class JobPosting(Model):
     standard_job_id: str
     country_code: Optional[str] = None
     days_to_hire: Optional[int] = None
+
+
+@mapper_registry.mapped
+@dataclass
+class DaysToHireStats(Model):
+    __table__ = Table(
+        "days_to_hire_stats",
+        mapper_registry.metadata,
+        Column("id", String, nullable=False, primary_key=True),
+        Column("standard_job_id", String, nullable=False),
+        Column("country_code", String, nullable=True),
+        Column("min_days", Float, nullable=False),
+        Column("avg_days", Float, nullable=False),
+        Column("max_days", Float, nullable=False),
+        Column("job_postings_number", Integer, nullable=False),
+        schema="public",
+    )
+
+    id: str
+    standard_job_id: str
+    country_code: Optional[str]
+    min_days: float
+    avg_days: float
+    max_days: float
+    job_postings_number: int

--- a/migrations/versions/b97077496e90_add_days_to_hire_stats_table.py
+++ b/migrations/versions/b97077496e90_add_days_to_hire_stats_table.py
@@ -1,0 +1,33 @@
+"""add_days_to_hire_stats_table
+
+Revision ID: b97077496e90
+Revises: 991ecb2bf269
+Create Date: 2025-06-27 13:51:39.211126
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'b97077496e90'
+down_revision = '991ecb2bf269'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table('days_to_hire_stats',
+    sa.Column('id', sa.String(), nullable=False),
+    sa.Column('standard_job_id', sa.String(), nullable=False),
+    sa.Column('country_code', sa.String(), nullable=True),
+    sa.Column('min_days', sa.Float(), nullable=False),
+    sa.Column('avg_days', sa.Float(), nullable=False),
+    sa.Column('max_days', sa.Float(), nullable=False),
+    sa.Column('job_postings_number', sa.Integer(), nullable=False),
+    sa.PrimaryKeyConstraint('id'),
+    schema='public'
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('days_to_hire_stats', schema='public')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ fastapi = "^0.94.0"
 psycopg2 = "^2.9.5"
 sqlalchemy = "<1.4.10"
 alembic = "^1.10.2"
-
+uvicorn = "^0.21.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR implements a system to track and analyze days-to-hire statistics for job postings. The implementation follows the home task requirements and includes:

### What's Added
- New `days_to_hire_stats` table to store hiring timeline statistics
- CLI script to calculate and update statistics
- API endpoint to retrieve statistics by job and country

### Implementation Details
The statistics system:
- Filters outliers using 10th/90th percentiles for more accurate averages
- Processes data in chunks to handle large datasets efficiently
- Requires minimum 5 job postings for statistical significance
- Supports both country-specific and global statistics

### How to Use
1. Run the statistics calculation:
```bash
python -m home_task.cli
```

2. Query the statistics:
```http
GET /stats?standard_job_id=<id>&country_code=<optional_code>
```

Example response:
```json
{
    "standard_job_id": "123",
    "country_code": "DE",
    "min_days": 11.0,
    "avg_days": 50.5,
    "max_days": 80.9,
    "job_postings_number": 100
}
```

### Files Changed
- `models.py`: Added DaysToHireStats model
- `cli.py`: Added statistics calculation script
- `api.py`: Added stats endpoint